### PR TITLE
Bugfix: remove unexpected * from ecc_theme.theme

### DIFF
--- a/ecc_theme/ecc_theme.theme
+++ b/ecc_theme/ecc_theme.theme
@@ -95,7 +95,6 @@ function ecc_theme_suggestions_form_element_label_alter(&$suggestions, array $va
     }
   }
 
-*
 /**
  * Implements hook_preprocess_HOOK().
  * @TODO: remove this function if


### PR DESCRIPTION
remove unexpected * in ecc_theme.theme causing error in drupal 