### PR TITLE
ECCI-536: removes width calc causing icon to cut off

### DIFF
--- a/ecc_theme/css/ecc-shared/services.css
+++ b/ecc_theme/css/ecc-shared/services.css
@@ -8,7 +8,6 @@ This CSS file, services.css, is used to style a feature block component within a
     background-color: #3a7d64;
     text-align: center;
     float: left;
-    width: calc(50% - 0.5rem);
     margin-bottom: 1rem;
     overflow: hidden;
 }


### PR DESCRIPTION
- removes width calc that was causing icon to be cut off 
- this also fixes ECCW-669 

<img width="144" alt="Screenshot 2024-01-25 at 14 45 44" src="https://github.com/essexcountycouncil/ecc_theme/assets/77584099/e87b81ae-bdf0-4f37-a416-46482e5f5979">
