### PR TITLE
bugfix/ECCI-537-538: Adds styles for media-with-text

### DIFF
--- a/ecc_theme/css/ecc-shared/media-with-text.css
+++ b/ecc_theme/css/ecc-shared/media-with-text.css
@@ -16,7 +16,8 @@
     flex-grow: 1;
 }
 
-.media-with-text--media-bottom .media-with-text__inner {
+.media-with-text--media-bottom .media-with-text__inner,
+.media-with-text--media-top .media-with-text__inner {
     grid-template-columns: 1fr;
 }
 
@@ -63,12 +64,13 @@
     grid-template-columns: 1fr 2fr;
 }
 
-.media-with-text--media-right.media-with-text--featured .media-with-text__inner .media-with-text__body {
+.media-with-text--media-right.media-with-text--featured .media-with-text__inner .media-with-text__body,
+.media-with-text--media-top.media-with-text--featured .media-with-text__inner .media-with-text__body {
     grid-column: 1/2;
 }
 
 .media-with-text--media-left.media-with-text--featured .media-with-text__inner .media-with-text__body {
-    grid-column: 2/3;
+    grid-column: 3/3;
 }
 
 .media-with-text--featured .contextual-region {
@@ -87,7 +89,8 @@
     padding-right: var(--spacing);
 }
 
-.media-with-text.media-with-text--media-bottom .media-with-text__inner {
+.media-with-text.media-with-text--media-bottom .media-with-text__inner, 
+.media-with-text.media-with-text--media-top .media-with-text__inner {
     height: 100%;
     display: grid;
     grid-template-columns: 1fr;
@@ -98,6 +101,21 @@
     aspect-ratio: 1/1;
     border-radius: 50%;
     object-fit: cover;
+}
+
+.media-with-text--circle .media-with-text__body {
+    background-color: white;
+}
+
+.media-with-text.media-with-text--media-right .media-with-text__inner,
+.media-with-text.media-with-text--media-left .media-with-text__inner {
+    display: grid;
+    grid-template-columns: 1fr
+}
+
+
+.media-with-text.media-with-text--media-right .media-with-text__inner .media-with-text__body {
+    grid-area: 2
 }
 
 @media screen and (max-width: 560px) {
@@ -116,14 +134,16 @@
 
 @media screen and (min-width: 561px) {
 
-    .media-with-text .media-with-text__inner {
+    .media-with-text .media-with-text__inner,
+    .media-with-text.media-with-text--media-right .media-with-text__inner,
+    .media-with-text.media-with-text--media-left .media-with-text__inner {
         height: 100%;
         display: grid;
         grid-template-columns: 1fr 1fr;
     }
 
-    .media-with-text--featured .media-with-text__inner {
-        display: block;
+    .media-with-text.media-with-text--media-right .media-with-text__inner .media-with-text__body {
+        grid-area: 1
     }
 }
 

--- a/ecc_theme/css/ecc-shared/media-with-text.css
+++ b/ecc_theme/css/ecc-shared/media-with-text.css
@@ -113,7 +113,6 @@
     grid-template-columns: 1fr
 }
 
-
 .media-with-text.media-with-text--media-right .media-with-text__inner .media-with-text__body {
     grid-area: 2
 }


### PR DESCRIPTION
- Fixes bg-color for --circle
- creates vertical stacking display (with media on top) for mobile for --right and --left media components
- fixes --right and --left featured component

To do: Clarify max-width of --circle top and bottom components prior to merging. 

<img width="597" alt="Screenshot 2024-01-26 at 13 01 16" src="https://github.com/essexcountycouncil/ecc_theme/assets/77584099/f672aee6-5c8c-4bb2-9f02-13024ce8bf7b">
<img width="298" alt="Screenshot 2024-01-26 at 13 01 25" src="https://github.com/essexcountycouncil/ecc_theme/assets/77584099/e9e4ad3d-3adb-4246-94e8-c0eea988abe5">
