### PR TITLE
ECCI-541: adds spacing for header and :after

### DIFF
--- a/ecc_theme/css/ecc-shared/headings.css
+++ b/ecc_theme/css/ecc-shared/headings.css
@@ -17,14 +17,15 @@ h1,
 .navigation--quick-actions h2 {
   position: relative;
   margin: 0;
-  padding-bottom: var(--spacing-large);
+  padding-bottom: var(--spacing-small);
+  margin-bottom: var(--spacing-largest)
 }
 
 h1::after,
 .field--type-text-long h2::after,
 .navigation--quick-actions h2::after {
   position: absolute;
-  bottom: 0;
+  bottom: -15px;
   left: 0;
   width: 70px;
   height: 8px;


### PR DESCRIPTION
adds spacing for header and :after element

<img width="276" alt="Screenshot 2024-02-05 at 16 46 01" src="https://github.com/essexcountycouncil/ecc_theme/assets/77584099/c9959040-0e1c-47fc-982b-b135ffa1b2f7">
