### PR TITLE
ECCI-543: removes black bg from next/prev links

### DIFF
--- a/ecc_theme/css/ecc-shared/pagination.css
+++ b/ecc_theme/css/ecc-shared/pagination.css
@@ -29,7 +29,3 @@ a.lgd-prev-next__link:hover .link_title {
   margin-left: 0.625rem;
 }
 
-.lgd-prev-next__list .lgd-prev-next__link {
-  border-color: var(--color-black);
-  background-color: var(--color-black);
-}


### PR DESCRIPTION
removes black bg on these links:
<img width="310" alt="Screenshot 2024-02-05 at 17 02 26" src="https://github.com/essexcountycouncil/ecc_theme/assets/77584099/fd18624f-eaf4-49ad-82aa-f6a33eceb916">
