### PR TITLE
ECCI-538: Removal of width causes circle to render properly.

### DIFF
--- a/ecc_theme/css/ecc-shared/layout.css
+++ b/ecc_theme/css/ecc-shared/layout.css
@@ -25,7 +25,6 @@
 }
 
 .layout .media-with-text:not(.media-with-text--featured) .media-with-text__media * {
-  width: 100%;
   height: 100%;
   object-fit: cover;
 }


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Using devtools, I found disabling `width` around line 28 of this file, and the image no longer appears as an oval.
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
  - There are no links.
- Why have you taken the approach?
  - It was one of the few things that I know how to do.
- Any particular problem areas?
  - I'm not convinced that this _doesn't_ introduce regressions this stage.
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
---
*Before:*
![image](https://github.com/essexcountycouncil/ecc_theme/assets/158008/e7776b63-9ce8-482f-a6d6-9b7610bc76b2)
---
*After:*
![image](https://github.com/essexcountycouncil/ecc_theme/assets/158008/59a383e1-b747-4a5a-bd6c-ef663d86bfde)
---
## This PR has been tested in the following browsers
- [x] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
