### PR TITLE
ECCW-675: Missing buttons.css file for ecc_theme_gov theme.

### DIFF
--- a/ecc_theme_gov/css/buttons.css
+++ b/ecc_theme_gov/css/buttons.css
@@ -1,8 +1,0 @@
-.button {
-  width: max-content;
-  padding: var(--spacing-small) var(--spacing);
-  cursor: pointer;
-  text-decoration: none;
-  color: var(--color-white);
-  background: var(--color-accent);
-}

--- a/ecc_theme_gov/css/buttons.css
+++ b/ecc_theme_gov/css/buttons.css
@@ -1,0 +1,8 @@
+.button {
+  width: max-content;
+  padding: var(--spacing-small) var(--spacing);
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--color-white);
+  background: var(--color-accent);
+}

--- a/ecc_theme_gov/ecc_theme_gov.libraries.yml
+++ b/ecc_theme_gov/ecc_theme_gov.libraries.yml
@@ -13,11 +13,6 @@ service_cta_block:
     theme:
       css/service-cta-block.css: { weight: 2 }
 
-buttons:
-  css:
-    theme:
-      css/buttons.css: { weight: 2 }
-
 header:
   css:
     theme:


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
While prepping the gov site to use 1.0.16, I spotted errors the `buttons.css` file was not present.
## Call out any relevant implementation decisions
- Why have you taken the approach?
  - I suspect that there may be some necessary styling for buttons, but don't know what the design requirements are, so duplicated the intranet site and am creating this PR as a draft until a decision is made.
  - If not needed, the file will need removing, as does the reference to it in `ecc_theme_gov.libraries.yml`.
- Any particular problem areas?
  - None whatsoever in my limited skim though the site in my local build. As I saw no difference, when comparing to prod, perhaps it's not needed whatsoever?
## This PR has been tested in the following browsers
- [x] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
