### PR TITLE
ECCI-525: Adding the news.css file to the intranet theme.

### DIFF
--- a/ecc_theme_intranet/css/news.css
+++ b/ecc_theme_intranet/css/news.css
@@ -1,0 +1,404 @@
+@media only screen and (min-width: 768px) {
+    .news-row {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .news-column {
+        margin-right: 2rem;
+        margin-bottom: 0;
+        width: calc(1/3*100% - (1 - 1/3)*2rem);
+    }
+
+    .news-column:nth-child(3n) {
+        margin-right: 0;
+    }
+
+    .lgd-teaser--localgov-news-article .lgd-teaser__image {
+        margin-bottom: 1.5rem;
+    }
+}
+
+.node--type-localgov-news-article picture>img {
+    max-inline-size: 100%;
+    block-size: auto;
+    height: auto;
+    object-fit: cover;
+    aspect-ratio: 9/5;
+}
+
+
+.link-block__title-wrapper {
+    align-items: flex-start;
+}
+
+/** News cards */
+div:has(.featured-teaser),
+.featured-teaser {
+    height: 100%;
+}
+
+.newsroom-teaser,
+.featured-news__card article,
+.news-card article {
+    background-color: var(--color-white);
+    border: 1px solid #cdcdcd;
+    border-bottom: 3px solid var(--color-accent);
+    margin-bottom: var(--spacing-large);
+    height: 100%;
+}
+
+.newsroom-teaser {
+    margin-bottom: 0;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+@media screen and (max-width: 640px) {
+    .newsroom-teaser {
+        padding-bottom: 0;
+        display: flex;
+    }
+
+    .newsroom-teaser__image {
+        flex: 1 0 45%;
+    }
+
+    .newsroom-teaser__image div,
+    .newsroom-teaser__image img {
+        height: 100%;
+    }
+
+    .newsroom-teaser__image img {
+        object-fit: cover;
+    }
+
+    .newsroom-teaser__content {
+        padding-bottom: var(--spacing-large);
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .newsroom-teaser {
+        padding-bottom: var(--spacing-large);
+    }
+
+    .featured-news__card article,
+    .news-card article {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+    }
+}
+
+.newsroom-teaser__title,
+.newsroom-teaser__summary {
+    padding: 0 var(--spacing);
+}
+
+.newsroom-teaser:hover,
+.featured-news__card article:hover,
+.news-card article:hover {
+    cursor: pointer;
+}
+
+.newsroom-teaser:hover .newsroom-teaser__title a,
+.featured-news__card article:hover a,
+.news-card article:hover a {
+    text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+}
+
+@media screen and (min-width: 1008px) {
+
+    .featured-news__card article,
+    .news-card article {
+        margin-bottom: 0;
+    }
+
+    .featured-news__card:first-of-type {
+        margin-bottom: var(--spacing-largest);
+    }
+}
+
+.news-card article a,
+.featured-news__card article a {
+    color: var(--color-black);
+}
+
+.featured-news__card .card-image,
+.news-card .card-image {
+    position: relative;
+}
+
+.featured-news__card .card-image div,
+.news-card .card-image div {
+    height: 100%;
+}
+
+.news-card .card-image img,
+.featured-news__card img {
+    object-fit: cover;
+    width: 100%;
+    height: 100%
+}
+
+@media screen and (min-width: 768px) {
+    .news-card .card-image img {
+        object-fit: cover;
+        aspect-ratio: 41/30;
+    }
+
+    .featured-news__card img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+        aspect-ratio: auto;
+    }
+
+}
+
+.featured-news__card article .card-content {
+    font-size: 1.25rem;
+}
+
+@media (min-width: 641px) {
+    .field.news-card {
+        width: auto;
+    }
+
+    @supports (subgrid) {
+        .paragraph--type--newsroom-component {
+            display: grid;
+            grid-template-columns: subgrid;
+        }
+    }
+}
+
+.featured-news__card article .card-content,
+.news-card article .card-content {
+    grid-column: 2 / span 2;
+    padding: 0.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.featured-news__card article .card-content p,
+.news-card article .card-content p,
+.field--name-localgov-text p {
+    --font-size: clamp(1rem, 0.85rem + 0.5vw, 1.125rem);
+    --line-height: 1.5;
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+}
+
+.featured-news__card article .card-content .node__content,
+.news-card article .card-content .node__content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.news-card .field--type-datetime,
+.featured-news__card .field--type-datetime {
+    text-align: right;
+    font-size: var(--font-size-small);
+    vertical-align: bottom;
+    margin-top: auto;
+}
+
+@media (max-width: 640px) {
+
+    .featured-news__card h3,
+    .news-card h3 {
+        margin-top: 5px;
+        font-size: var(--font-size-h6);
+    }
+
+    .card-content .field--name-body {
+        font-size: 0.875rem;
+    }
+}
+
+@media (min-width: 768px) {
+    .news-card article {
+        background: none;
+    }
+
+    .featured-news__card article {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
+
+    .news-card {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-auto-rows: 1fr;
+        grid-gap: 1em;
+        margin: 0;
+    }
+
+    .featured-news__card .card-image {
+        grid-column: 1 / span 2;
+    }
+
+    .featured-news__card article .card-content {
+        grid-column: 3 / span 2;
+        min-height: 240px;
+    }
+
+    .featured-news__card article .card-content {
+        padding: 1.25rem 1rem;
+    }
+
+    .news-card article .card-image,
+    .news-card article .card-content {
+        grid-column: 1 / span 3;
+    }
+
+    .card-content {
+        position: relative;
+        padding: 10px;
+    }
+
+    .featured-news__card .field--type-datetime {
+        position: absolute;
+        bottom: 10px;
+        right: 10px;
+    }
+}
+
+.news-card article,
+.featured-news__card article {
+    box-shadow: 0px 0 2px rgba(0, 0, 0, 0.25);
+}
+
+/* News 1+4 component */
+
+.paragraph--type--news-1-4 {
+    margin-bottom: var(--spacing)
+}
+
+.paragraph--type--news-1-4 .news-card article,
+.paragraph--type--news-1-4 .featured-news__card article,
+.paragraph--type--localgov-newsroom-teaser2 .news-card article {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+}
+
+.paragraph--type--news-1-4 .news-card,
+.paragraph--type--localgov-newsroom-teaser2 .news-card {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-gap: 1rem;
+    grid-auto-rows: auto !important
+}
+
+.paragraph--type--news-1-4 article .card-image,
+.paragraph--type--localgov-newsroom-teaser2 article .card-image {
+    grid-column: 1/2 !important;
+}
+
+.paragraph--type--news-1-4 .featured-news__card article .card-content,
+.paragraph--type--news-1-4 .news-card article .card-content,
+.paragraph--type--localgov-newsroom-teaser2 .featured-news__card article .card-content,
+.paragraph--type--localgov-newsroom-teaser2 .news-card article .card-content {
+    grid-column: 2/3 !important;
+    height: 100%;
+}
+
+@media screen and (min-width: 768px) {
+
+    .paragraph--type--news-1-4 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr;
+        gap: var(--spacing);
+    }
+
+    .paragraph--type--news-1-4 .news-card {
+        display: grid;
+        grid-column: 2 / 3;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto;
+        grid-gap: 1rem;
+    }
+
+    .paragraph--type--news-1-4 .featured-news__card,
+    .paragraph--type--localgov-newsroom-teaser2 .featured-news__card {
+        grid-column: 1 / 2;
+
+    }
+
+    .paragraph--type--news-1-4 .featured-news__card:first-of-type {
+        margin-bottom: 0;
+    }
+
+    .paragraph--type--news-1-4 .featured-news__card article,
+    .paragraph--type--news-1-4 .news-card article,
+    .paragraph--type--localgov-newsroom-teaser2 .featured-news__card article,
+    .paragraph--type--localgov-newsroom-teaser2 .news-card article {
+        display: flex;
+        flex-direction: column;
+        grid-template-columns: 1fr;
+    }
+
+    .paragraph--type--news-1-4 .featured-news__card .card-image img,
+    .paragraph--type--localgov-newsroom-teaser2 .featured-news__card .card-image img {
+        position: static;
+        aspect-ratio: auto;
+    }
+
+    .paragraph--type--news-1-4 .featured-news__card .card-content,
+    .paragraph--type--localgov-newsroom-teaser2 .featured-news__card .card-content {
+        height: 100%;
+    }
+
+    .paragraph--type--news-1-4 .news-card .card-image img,
+    .paragraph--type--localgov-newsroom-teaser2 .news-card .card-image img {
+        aspect-ratio: 41 / 30;
+    }
+
+}
+
+.field__item+.news-article__related-title {
+    margin-top: var(--spacing-mega);
+}
+
+.field__item+.news-article__related-title {
+    margin-top: var(--spacing-mega);
+}
+
+.paragraph--type--news-1-4 .card-image img,
+.paragraph--type--localgov-newsroom-teaser2 .card-image img {
+    width: 100%;
+    aspect-ratio: 41 / 30;
+    object-fit: cover;
+}
+
+.paragraph--type--localgov-newsroom-teaser2 {
+  height: 100%;
+  .news-card {
+    height: 100%;
+  }
+  article {
+    min-width: 0;
+  }
+}
+
+p:has(a+i) {
+    display: flex;
+    align-items: center;
+}
+
+a+i {
+    margin-left: 0.2rem;
+    margin-top: 0.2rem;
+    color: var(--color-link);
+}
+
+.news-article__content>*+* {
+    margin-top: var(--spacing);
+}
+
+.views-view-grid .views-col {
+    float: unset;
+}

--- a/ecc_theme_intranet/ecc_theme_intranet.info.yml
+++ b/ecc_theme_intranet/ecc_theme_intranet.info.yml
@@ -15,6 +15,7 @@ libraries:
   - ecc_theme_intranet/main_menu
   - ecc_theme_intranet/search
   - ecc_theme_intranet/service_cta_block
+  - ecc_theme_intranet/news
 
 regions:
   tabs: "Tabs"

--- a/ecc_theme_intranet/ecc_theme_intranet.libraries.yml
+++ b/ecc_theme_intranet/ecc_theme_intranet.libraries.yml
@@ -37,6 +37,11 @@ main_menu:
     theme:
       css/main-menu.css: { weight: 2 }
 
+news:
+  css:
+    theme:
+      css/news.css: { weight: 2 }
+
 layout.css:
   css:
     theme:


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
This adds the news.css from the legacy intranet theme to the new intranet theme.
## Call out any relevant implementation decisions
- Why have you taken the approach?

To validate that the news.css file would load, I simply added it the legacy file. It rendered first time.
## Screenies
*Before:*
![image](https://github.com/essexcountycouncil/ecc_theme/assets/158008/da91d3ff-a979-42c4-909f-7a035d36b9f0)

---

*After:*
![image](https://github.com/essexcountycouncil/ecc_theme/assets/158008/2474185a-2f2a-4d9f-9778-f47ec7b279aa)


---

## This PR has been tested in the following browsers
- [x] Arc