### PR TITLE
ECCI-544: Move start button colours to shared theme.

### DIFF
--- a/ecc_theme/css/ecc-shared/variables-shared.css
+++ b/ecc_theme/css/ecc-shared/variables-shared.css
@@ -47,6 +47,8 @@ body {
   --alert-banner-color: var(--color-black);
   --breadcrumbs-link-color: var(--color-black);
   --background-blue: #004c94;
+  --btn-start-bg-color: #00823b;
+  --btn-start-color-hover: #00823b;
   --color-accent: #e40037;
   --color-blue: #4179aa;
   --color-danger: #e40037;

--- a/ecc_theme_gov/css/variables-gov.css
+++ b/ecc_theme_gov/css/variables-gov.css
@@ -6,8 +6,6 @@ body {
   --background-blue: #004c94;
   --banner-content-bg-color: var(--color-white);
   --banner-content-text-color: var(--color-black);
-  --btn-start-bg-color: #00823b;
-  --btn-start-color-hover: #00823b;
   --color-section-header-bg: var(--color-white);
   --color-section-pre-footer-bg: var(--color-black);
   --header-search-button-color-hover: var(--color-black);


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Start button should be green for both websites so the variables should be in the shared theme. (Currently missing from Intranet)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
