### PR TITLE
ECCI-541: Formatting issue on service landing pages

### DIFF
--- a/ecc_theme/css/ecc-shared/layout.css
+++ b/ecc_theme/css/ecc-shared/layout.css
@@ -209,12 +209,19 @@
     color: var(--color-black);
   }
 
-  .lgd-row:has(.lgd-row__one-third) > * {
-    margin: 0;
+  .lgd-row__full {
+    width: calc(100% - var(--grid-column-spacing));
   }
 
-  .lgd-row:has(.lgd-row__one-third) > * + * {
-    margin-left: var(--spacing-large);
+  .service-landing-page__service.field__item.lgd-row__one-third {
+    margin-right: calc(var(--grid-column-spacing) / 2);
+    margin-left: calc(var(--grid-column-spacing) / 2);
+  }
+
+  .lgd-teaser-list .service-landing-page__service {
+    margin-bottom: var(--vertical-rhythm-spacing);
+    padding-bottom: var(--vertical-rhythm-spacing);
+    border-bottom: var(--border);
   }
 
   .lgd-row .service-cta-block__list-item {


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
On service landing pages, the link text in of second rows onwards appear to have an indent. 

Screenshot Pre-prod Intranet
<img width="458" alt="84f84321-89c9-498f-abec-ce0e0e5e350a" src="https://github.com/essexcountycouncil/ecc_theme/assets/56226/463a552d-3dab-4310-9cdb-5c7be21df764">
## Call out any relevant implementation decisions


- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
