### PR TITLE
ECCI-549 Changed body font-size to be consistent with live site

### DIFF
--- a/ecc_theme/css/ecc-shared/variables-shared.css
+++ b/ecc_theme/css/ecc-shared/variables-shared.css
@@ -20,7 +20,7 @@ body {
   --font-size-larger: clamp(1.4375rem, 1.3rem + 0.5vw, 1.5625rem);
   --font-size-largest: clamp(2.1875rem, 2rem + 0.75vw, 2.375rem);
   --font-size-small: clamp(0.875rem, 0.7rem + 0.5vw, 1rem);
-  --font-size: clamp(1rem, 0.85rem + 0.5vw, 1.125rem);
+  --font-size: 1rem;
 
   /**
     Font-weight


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
The variable font-size for the body has been changed to use the same as the live site.
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
