### PR TITLE
ECCI-563 fixed quick links position on mobile

### DIFF
--- a/ecc_theme/css/ecc-shared/layout.css
+++ b/ecc_theme/css/ecc-shared/layout.css
@@ -100,6 +100,19 @@
   height: 100%;
 }
 
+.paragraph.paragraph--type--newsroom-component {
+  padding-top: 0;
+}
+
+.paragraph--type--localgov-text {
+  margin: var(--spacing-larger) 0;
+  padding: 0;
+}
+
+.paragraph--type--localgov-media-with-text {
+  padding-top: 0;
+}
+
 .paragraph--type--localgov-newsroom-teaser2 .news-card article > .card-content::before {
   position: absolute;
   right: 0;

--- a/ecc_theme_intranet/css/hero.css
+++ b/ecc_theme_intranet/css/hero.css
@@ -43,9 +43,6 @@
 
 .path-frontpage .banner h1 {
   --font-size-h1: clamp(1.5rem, 2.5vw, 2.562rem);
-
-  -moz-width: fit-content;
-  width: fit-content;
   padding: calc(var(--spacing) - 0.5px) var(--spacing-large);
 }
 

--- a/ecc_theme_intranet/css/search.css
+++ b/ecc_theme_intranet/css/search.css
@@ -40,6 +40,11 @@
   min-height: 59px;
 }
 
+@media (max-width: 759px) {
+  .cludo-search-block-search-form form {
+    margin: 5rem 0 7.25rem;
+  }
+}
 @media (min-width: 760px) {
   .path-frontpage .cludo-search-block-search-form input {
     font-size: var(--font-size-large);


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Fixed quick links position on mobile and added space of 1rem
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
<img width="367" alt="Screenshot 2024-03-04 at 11 37 19 AM" src="https://github.com/essexcountycouncil/ecc_theme/assets/160479045/6231f68e-90eb-475d-99f5-0c1946537ac8">
<img width="378" alt="Screenshot 2024-03-04 at 11 37 24 AM" src="https://github.com/essexcountycouncil/ecc_theme/assets/160479045/2d294226-e182-424f-acad-afebf5779faf">

## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
