### PR TITLE
LP-87: Remove duplicate functions from themes.

### DIFF
--- a/ecc_theme_gov/ecc_theme_gov.theme
+++ b/ecc_theme_gov/ecc_theme_gov.theme
@@ -8,53 +8,6 @@ use Drupal\block\Entity\Block;
  */
 
 /**
- * Implements hook_preprocess_HOOK() for block templates.
- *
- * @param $variables
- *   Template variables
- * @param $hook
- *   Type of template.
- *
- * Load blocks from specific region, so we can render them within a template.
- */
-function ecc_theme_gov_preprocess_paragraph__localgov_banner_primary(&$variables) {
-  // Load active theme
-  $theme = \Drupal::theme()->getActiveTheme()->getName();
-  // Load region blocks
-  $blocks = \Drupal::entityTypeManager()
-    ->getStorage('block')
-    ->loadByProperties(array('theme' => $theme, 'region' => 'hero_content'));
-
-  try {
-    // Capture the region's viewable blocks and their settings.
-    $build = [];
-    foreach ($blocks as $key => $block) {
-      if ($block->access('view')) {
-        $block = Block::load($key);
-        $block_content = \Drupal::entityTypeManager()
-          ->getViewBuilder('block')
-          ->view($block);
-        $build[$key] = $block_content;
-      }
-    }
-
-    // Add the region's worth of viewable blocks to the available variables.
-    $variables['banner_content'] = $build;
-  } catch (Exception $e) {
-    $variables['banner_content'] = NULL;
-  }
-
-  try {
-    $variables['is_front'] = Drupal::service('path.matcher')->isFrontPage();
-  }
-  catch (Exception $e) {
-    $variables['is_front'] = FALSE;
-  }
-  // Ensure the cache varies correctly (new in Drupal 8.3).
-  $variables['#cache']['contexts'][] = 'url.path.is_front';
-}
-
-/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function ecc_theme_gov_theme_suggestions_form_element_label_alter(&$suggestions, array $variables) {
@@ -73,24 +26,3 @@ function ecc_theme_gov_theme_suggestions_form_element_label_alter(&$suggestions,
   }
 }
 
-/**
- * Implements hook_preprocess_breadcrumb().
- */
-function ecc_theme_gov_preprocess_breadcrumb(&$variables) {
-  $request = \Drupal::request();
-  $route_match = \Drupal::routeMatch();
-
-  $node = $route_match->getParameter('node');
-
-  // ECCW-633: Remove duplicate breadcrumb on subsites pages.
-  if (!$node || $node->bundle() !== 'localgov_subsites_page') {
-    $page_title = \Drupal::service('title_resolver')
-      ->getTitle($request, $route_match->getRouteObject());
-
-    // Append new item (text only) to breadcrumb for the current page title.
-    $variables['breadcrumb'][] = [
-      'text' => $page_title
-    ];
-  }
-  $variables['#cache']['contexts'][] = 'url';
-}

--- a/ecc_theme_intranet/ecc_theme_intranet.theme
+++ b/ecc_theme_intranet/ecc_theme_intranet.theme
@@ -1,77 +1,8 @@
 <?php
 
-use Drupal\block\Entity\Block;
-
 /**
  * @file
  * Theme function for the Essex County Council Intranet theme.
  */
 
-/**
- * Implement hook_preprocess_HOOK
- *
- * @param $variables
- *   Template variables
- * @param $hook
- *   Type of template.
- *
- * Load blocks from specific region, so we can render them within a template.
- */
-function ecc_theme_intranet_preprocess_paragraph__localgov_banner_primary(&$variables, $hook) {
-  // Load active theme
-  $theme = \Drupal::theme()->getActiveTheme()->getName();
-  // Load region blocks
-  $blocks = \Drupal::entityTypeManager()
-    ->getStorage('block')
-    ->loadByProperties(array('theme' => $theme, 'region' => 'hero_content'));
 
-  try {
-    // Capture the region's viewable blocks and their settings.
-    $build = [];
-    foreach ($blocks as $key => $block) {
-      if ($block->access('view')) {
-        $block = Block::load($key);
-        $block_content = \Drupal::entityTypeManager()
-          ->getViewBuilder('block')
-          ->view($block);
-        $build[$key] = $block_content;
-      }
-    }
-
-    // Add the region's worth of viewable blocks to the available variables.
-    $variables['banner_content'] = $build;
-  } catch (Exception $e) {
-    $variables['banner_content'] = NULL;
-  }
-
-  try {
-    $variables['is_front'] = Drupal::service('path.matcher')->isFrontPage();
-  }
-  catch (Exception $e) {
-    $variables['is_front'] = FALSE;
-  }
-  // Ensure the cache varies correctly (new in Drupal 8.3).
-  $variables['#cache']['contexts'][] = 'url.path.is_front';
-}
-
-/**
- * Implements hook_preprocess_breadcrumb().
- */
-function ecc_theme_intranet_preprocess_breadcrumb(&$variables) {
-  $request = \Drupal::request();
-  $route_match = \Drupal::routeMatch();
-
-  $node = $route_match->getParameter('node');
-
-  // ECCI-393: Remove duplicate breadcrumb on subsites pages.
-  if (!$node || $node->bundle() !== 'localgov_subsites_page') {
-    $page_title = \Drupal::service('title_resolver')
-      ->getTitle($request, $route_match->getRouteObject());
-
-    // Append new item (text only) to breadcrumb for the current page title.
-    $variables['breadcrumb'][] = [
-      'text' => $page_title
-    ];
-  }
-  $variables['#cache']['contexts'][] = 'url';
-}


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/bff21712-658e-4f51-9e91-c4dfa81e6b73)
The last breadcrumb is duplicated because of identical functions in ecc_theme and ecc_theme_gov for hook_preprocess_breadcrumb.

Remove two hooks from ecc_theme_gov and ecc_theme_intranet which are also present in ecc_theme

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
