### PR TITLE
LP-26: Update theme name for add-to-calendar.twig

### DIFF
--- a/ecc_theme/templates/content/node--localgov-event--full.html.twig
+++ b/ecc_theme/templates/content/node--localgov-event--full.html.twig
@@ -133,7 +133,7 @@
 
       <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
         {{ content.localgov_event_date }}
-        {% include "@essex/_components/add-to-calendar.twig" %}
+        {% include "@ecc_theme/_components/add-to-calendar.twig" %}
         {{ content|without('localgov_event_date') }}
       </div>
 


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Fixes this error which refers to the old _essex_ theme
`php.ERROR: Twig\Error\LoaderError: Template "@essex/templates/_components/add-to-calendar.twig" is not defined in "themes/contrib/ecc_theme/ecc_theme/templates/content/node--localgov-event--full.html.twig" at line 136. in Twig\Loader\ChainLoader->getCacheKey() (line 99 of /drupal/vendor/twig/twig/src/Loader/ChainLoader.php).`
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
