### PR TITLE
adds spacing between items for events in full view mode

### DIFF
--- a/ecc_theme/css/ecc-shared/events.css
+++ b/ecc_theme/css/ecc-shared/events.css
@@ -45,3 +45,7 @@ This CSS file, events.css, is used to style an events listing component.
   padding: var(--spacing);
   content: "";
 }
+
+.localgov-event__content > * + * {
+  margin-block-start: var(--vertical-rhythm-spacing);
+}


### PR DESCRIPTION
At the moment if an event has an image and a call to action, the CTA is bucking up against the image. This adds generic spacing to all items in the event content div.

Fixes: https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?assignee=557058%3A8b7fbfd8-fba0-4c51-bd41-0b1d0e7d6ebe&selectedIssue=LP-26