### PR TITLE
fix(FOS-85): Set background to white on active item in subsite menu.

### DIFF
--- a/ecc_theme_gov/css/subsites-menu.css
+++ b/ecc_theme_gov/css/subsites-menu.css
@@ -104,6 +104,10 @@
       height: 100%;
     }
 
+    .menu--subsites > .menu-item--active-trail a {
+      background-color: var(--color-white);
+    }
+
     .subsite-extra__header-toggle-button {
       display: none;
     }


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Before:
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/ce1e607f-8447-4aba-ab2c-de0c726a3579)
After
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/1da8a59b-ded7-4209-bc0f-0de25c0428fd)


## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
