### PR TITLE
fix(FOS-79): Reduce spacing between quote and text paragraph.

### DIFF
--- a/ecc_theme/css/ecc-shared/layout.css
+++ b/ecc_theme/css/ecc-shared/layout.css
@@ -6,6 +6,10 @@
   margin-top: var(--grid-gap);
 }
 
+.paragraph--type--localgov-quote + .paragraph--type--localgov-text {
+  margin-top: var(--spacing-gap-smaller)
+}
+
 .layout--onecol .layout__region {
   padding: 0;
 }


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
The spacing between paragraphs is too large when a "Read more" link is associated with a pull quote above it. 

![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/d60d4dfb-d028-45e1-b77b-8555b45d07c4)

The best solution would be to add a new link field to the quote paragraph but this is out of scope for now. A compromise is to reduce the margin above a text paragraph when it immediately follows a quote.
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/9f4d8e1f-95ef-461e-ab2c-d4d87c550aaa)

The spacing was adjusted earlier but was still too large
https://github.com/essexcountycouncil/ecc_theme/commit/0a81f7ea203ab35f3429f49d82616326cca0e59b

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
