### PR TITLE
fix(FOS-86): Reduce top margin for subsites search bar

### DIFF
--- a/ecc_theme_gov/css/subsites.css
+++ b/ecc_theme_gov/css/subsites.css
@@ -16,4 +16,8 @@ body.subsite-extra--color-fostering {
       text-decoration-line: none;
     }
   }
+
+  .lgd-region--search {
+    margin-top: 0.5rem;
+  }
 }


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
The purple background and white line make it obvious that the margin above the search bar is too big. 
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/293bf6ad-4ab1-410b-939f-848446ed4616)

This change only affects subsites in case of unexpected consequences on the rest of the website.
![image](https://github.com/essexcountycouncil/ecc_theme/assets/56226/5c082b0a-09b1-451d-8f95-c78245ec5556)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
