### PR TITLE
Create template for service sub-landing to include an <h2> to meet WC…

### DIFF
--- a/ecc_theme/templates/content/node--localgov-services-sublanding--full.html.twig
+++ b/ecc_theme/templates/content/node--localgov-services-sublanding--full.html.twig
@@ -5,11 +5,6 @@
  */
 #}
 
-{#
-  For shorthand, let's abbreviate our classes from .service-landing-page to
-  .service-landing-page
-#}
-
 {%
   set classes = [
     'service-sublanding-page',

--- a/ecc_theme/templates/content/node--localgov-services-sublanding--full.html.twig
+++ b/ecc_theme/templates/content/node--localgov-services-sublanding--full.html.twig
@@ -1,0 +1,48 @@
+{#
+/**
+ * @file
+ * Default node template for localgov_services_sub_landing pages.
+ */
+#}
+
+{#
+  For shorthand, let's abbreviate our classes from .service-landing-page to
+  .service-landing-page
+#}
+
+{%
+  set classes = [
+    'service-sublanding-page',
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+
+<article{{ attributes.addClass(classes).removeAttribute('role') }}>
+  <div class="lgd-container padding-horizontal">
+      <div class="lgd-row">
+
+        {# Begin Main Content #}
+        <div class="lgd-row__full">
+          {# Begin Services List #}
+          {% if node.localgov_topics.value %}
+            <h2 class="visually-hidden">{{ 'Services List'|t }}</h2>
+            <section class="service-sub-landing-page__services lgd-teaser-list">
+              {{ content.localgov_topics }}
+            </section>
+          {% endif %}
+          {# End Services List #}
+        </div>
+
+        <div{{ content_attributes.addClass(content_type|clean_class ~ '__content', 'node__content') }}>
+          {{ content|without('localgov_subsites_content', 'localgov_topics') }}
+        </div>
+
+
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
…AG 1.3.1

## Include a summary of what this merge request involves (*)
Adds a visually_hidden `<h2>` in order to resolve the heading structure hierarchy issue
## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
