### PR TITLE
Bugfix/lp 160

### DIFF
--- a/ecc_theme/css/ecc-shared/edit-tabs.css
+++ b/ecc_theme/css/ecc-shared/edit-tabs.css
@@ -2,10 +2,12 @@
   @TODO remove this CSS when
   https://github.com/localgovdrupal/localgov_base/issues/518
   is resolved.
+  Set top to a fixed value as drupal-displace-offset-top does fix the tabs
+  immediately below the toolbar.
 */
 .region-tabs {
   position: sticky;
   z-index: 100;
-  top: var(--drupal-displace-offset-top, 53px);
+  top: 53px;
 }
 /* End @TODO */

--- a/ecc_theme/ecc_theme.theme
+++ b/ecc_theme/ecc_theme.theme
@@ -108,10 +108,10 @@ function essex_preprocess_block(&$variables) {
   if ($variables['logged_in']) {
     // Get block id.
     $block_id = $variables['elements']['#id'];
-    $variables['#attached']['library'][] = 'essex/edit-tabs';
+    $variables['#attached']['library'][] = 'ecc_theme/edit-tabs';
     if ($block_id === 'essex_localgov_tabs_scarfolk') {
       // Attach library.
-      $variables['#attached']['library'][] = 'essex/edit-tabs';
+      $variables['#attached']['library'][] = 'ecc_theme/edit-tabs';
     }
   }
 }

--- a/ecc_theme/templates/content/node--localgov-newsroom--full.html.twig
+++ b/ecc_theme/templates/content/node--localgov-newsroom--full.html.twig
@@ -1,0 +1,134 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{%
+    set classes = [
+    'newsroom',
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+]
+%}
+
+{% if not localgov_base_remove_css %}
+    {{ attach_library('localgov_base/sidebar') }}
+    {{ attach_library('localgov_base/news') }}
+{% endif %}
+
+<article{{ attributes.addClass(classes).removeAttribute('role') }}>
+    <div class="lgd-container padding-horizontal">
+
+        {{ title_prefix }}
+        {{ title_suffix }}
+
+        {% if display_submitted %}
+            <footer class="node__meta">
+                {{ author_picture }}
+                <div{{ author_attributes.addClass('node__submitted') }}>
+                    {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
+                    {{ metadata }}
+                </div>
+            </footer>
+        {% endif %}
+
+        <div{{ content_attributes.addClass('newsroom__content', 'node__content') }}>
+
+            {{ content|without('localgov_news_search', 'localgov_news_facets', 'localgov_newsroom_all_view',
+                'localgov_page_components', 'field_content_owner', 'field_content_sme') }}
+
+            {#
+            Render the search, facets, etc here, followed by the news items
+            #}
+            <div class="lgd-row">
+                {# Remove facets from display #}
+                <div class="lgd-row__two-thirds">
+                    {{ content.localgov_newsroom_all_view }}
+                </div>
+            </div>
+
+            {#
+            Render the page components followed by the owner and SME fields
+            #}
+            {% if content.localgov_page_components %}
+                <div class="lgd-row__two-thirds">
+                    {{ content.localgov_page_components }}
+                </div>
+            {% endif %}
+
+        </div>
+    </div>
+
+</article>


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)

LP-160: Make tabs region sticky immediately below toolbar.
LP-72: Restore newsroom template (it can't be removed from ecc_theme until the new layout has been tested, as it affects Gov and Intranet)

The tabs menu is no longer sticky immediately below the toolbar. I can't see why the behaviour has changed. The stickiness was added here by Mark. When we upgrade LocalGov Base, we can test again and may be able to remove this file.
![image](https://github.com/user-attachments/assets/3e593e36-393e-4872-ac6b-a2f6a98481ae)


## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
