### PR TITLE
Add right padding to accordion button to avoid clash at high zoom.

### DIFF
--- a/ecc_theme/css/ecc-shared/accordion.css
+++ b/ecc_theme/css/ecc-shared/accordion.css
@@ -5,6 +5,7 @@ This CSS file, accordion.css, is used to style an accordion component. An accord
   position: relative;
   border-color: var(--color-link);
   background-color: var(--color-link);
+  padding-right: 3.5em;
 }
 
 .accordion-pane button::after {


### PR DESCRIPTION
Avoids clash between text and accordion chevron at high levels of desktop browser zoom.
Ticket: https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?selectedIssue=LP-125

## This PR has been tested in the following browsers
- [ ] Arc
- [x] Edge
- [ ] Chrome
- [ ] Safari
- [x] Firefox
- [ ] IE 11 (Windows)
- [x] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
