### PR TITLE
202408 skiplink lp 127

### DIFF
--- a/ecc_theme/ecc_theme.libraries.yml
+++ b/ecc_theme/ecc_theme.libraries.yml
@@ -7,6 +7,13 @@ fonts:
     theme:
       css/ecc-shared/fonts.css: { weight: 1 }
 
+skip-link:
+  js:
+    js/skip-link.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Components
 grid:
   css:

--- a/ecc_theme/ecc_theme.theme
+++ b/ecc_theme/ecc_theme.theme
@@ -121,6 +121,7 @@ function ecc_theme_preprocess_html(&$variables) {
   if ($route_name === 'view.localgov_events_listing.page_all_events') {
     $variables['attributes']['class'][] = 'events-listing-page';
   }
+    $variables['#attached']['library'][] = 'ecc_theme/skip-link';
 }
 
 /**

--- a/ecc_theme/js/skip-link.js
+++ b/ecc_theme/js/skip-link.js
@@ -1,0 +1,26 @@
+/**
+ * @file Handles IOS bug when trying to use skip link with keyboard.
+ */
+
+(function localgovSkiplink(Drupal) {
+  Drupal.behaviors.skiplink = {
+    attach: function (context) {
+      const [anchor] = once('maincontent', '[href="#main-content"]', context);
+      if (!anchor) {
+        return;
+      }
+      anchor.addEventListener('keydown', (e) => {
+        focusContent(e);
+      });
+
+      function focusContent(e) {
+        const { key } = e;
+        if (key === 'Enter') {
+          var mainContent = document.querySelector('#main-content');
+          mainContent.focus();
+          mainContent.setAttribute('tabindex', 0);
+        }
+      }
+    }
+  };
+}(Drupal));

--- a/ecc_theme_gov/templates/layout/page.html.twig
+++ b/ecc_theme_gov/templates/layout/page.html.twig
@@ -106,7 +106,9 @@
   {{ page.messages }}
 {% endif %}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main">
+  {# The "skip to content" link jumps to here. #}
+  <a id="main-content" />
 
   {% if has_content_top %}
     {{ page.content_top }}

--- a/ecc_theme_intranet/templates/layout/page.html.twig
+++ b/ecc_theme_intranet/templates/layout/page.html.twig
@@ -107,7 +107,9 @@ tabs region on all localgov_drupal websites. Yay!
   {{ page.messages }}
 {% endif %}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main">
+  {# The "skip to content" link jumps to here. #}
+  <a id="main-content" />
 
   {% if has_content_top %}
     {{ page.content_top }}


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-127

Addresses the issue where users attempting keyboard navigation with an external keyboard and IOS cannot use the `skip to main content` link, as further use of `tab` brings focus back to the the skip link.

Elements:

- new custom JS library
- preprocess function to load it
- a new `anchor` element in the page.html.twig templates for both .gov and intranet.

