### PR TITLE
Add tabindex -1 to main element for both gov and intranet

### DIFF
--- a/ecc_theme_gov/templates/layout/page.html.twig
+++ b/ecc_theme_gov/templates/layout/page.html.twig
@@ -106,7 +106,7 @@
   {{ page.messages }}
 {% endif %}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main" id="main-content" tabindex="-1"> {# The "skip to content" link jumps to here. #}
 
   {% if has_content_top %}
     {{ page.content_top }}

--- a/ecc_theme_intranet/templates/layout/page.html.twig
+++ b/ecc_theme_intranet/templates/layout/page.html.twig
@@ -107,7 +107,7 @@ tabs region on all localgov_drupal websites. Yay!
   {{ page.messages }}
 {% endif %}
 
-<main class="main" id="main-content"> {# The "skip to content" link jumps to here. #}
+<main class="main" id="main-content" tabindex="-1"> {# The "skip to content" link jumps to here. #}
 
   {% if has_content_top %}
     {{ page.content_top }}


### PR DESCRIPTION
A better, simpler solution for the Skip Link Problem. https://eccservicetransformation.atlassian.net/browse/LP-127
adds tabindex -1 to MAIN element, allowing focus.
Adds it in page.html.twig for both themes.