### PR TITLE
Make intranet line height base match .gov line height value

### DIFF
--- a/ecc_theme_intranet/css/variables-intranet.css
+++ b/ecc_theme_intranet/css/variables-intranet.css
@@ -7,7 +7,10 @@ body {
   --color-section-footer-bg: var(--color-black);
   --color-section-header-bg: #e40037;
   --color-section-pre-footer-bg: var(--background-blue);
-
+  /**
+    Line-height
+  */
+  --line-height: 1.5;
   /** misc */
   --header-logo-width: 200px;
   --line-height: 1.3;


### PR DESCRIPTION
makes the base line height the same as .gov theme.
1.5 units as opposed to 1.3.

https://eccservicetransformation.atlassian.net/browse/LP-176