### PR TITLE
Prepend DRAFT to node titles if unpublished.

### DIFF
--- a/ecc_theme/ecc_theme.theme
+++ b/ecc_theme/ecc_theme.theme
@@ -110,6 +110,22 @@ function essex_preprocess_block(&$variables) {
       // Attach library.
       $variables['#attached']['library'][] = 'ecc_theme/edit-tabs';
     }
+    // Mark Draft nodes as Draft.
+    if ($variables['plugin_id'] === 'localgov_page_header_block') {
+      $route_match = Drupal::routeMatch();
+      // Check if we are on a node page, latest version or a preview link.
+      $route = $route_match->getRouteName();
+      if ($route === 'entity.node.canonical' || $route === 'entity.node.latest_version' || $route === 'entity.node.preview_link') {
+        $node = $route_match->getParameter('node');
+        $node_status = $node->isPublished();
+        if ($node_status === FALSE) {
+          if (theme_get_setting('localgov_base_add_draft_note_to_unpublished_content')) {
+            $current_title = $variables['content'][0]['#title'];
+            $variables['content'][0]['#title'] = t('[Draft]') . " " . $current_title;
+          }
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-48

Adds to `ecc_theme_preprocess_block()` to prepend the word DRAFT to node titles if the user is logged in and the node is unpublished.