### PR TITLE
fix(LP-48):  Add schema to themes to ensure draft flag is boolean.

### DIFF
--- a/ecc_theme_gov/config/schema/ecc_theme_gov.schema.yml
+++ b/ecc_theme_gov/config/schema/ecc_theme_gov.schema.yml
@@ -1,0 +1,16 @@
+ecc_theme_gov.settings:
+  type: config_object
+  label: 'ECC Theme Gov settings'
+  mapping:
+    localgov_base_remove_css:
+      type: boolean
+      label: 'Remove CSS libraries from base theme.'
+    localgov_base_remove_js:
+      type: boolean
+      label: 'Remove JS libraries from base theme.'
+    localgov_base_add_unpublished_background_colour:
+      type: boolean
+      label: 'Add background colour to unpublished content.'
+    localgov_base_add_draft_note_to_unpublished_content:
+      type: boolean
+      label: 'Add "[Draft]" to title of unpublished content.'

--- a/ecc_theme_intranet/config/schema/ecc_theme_intranet.schema.yml
+++ b/ecc_theme_intranet/config/schema/ecc_theme_intranet.schema.yml
@@ -1,0 +1,16 @@
+ecc_theme_intranet.settings:
+  type: config_object
+  label: 'ECC Theme Intranet settings'
+  mapping:
+    localgov_base_remove_css:
+      type: boolean
+      label: 'Remove CSS libraries from base theme.'
+    localgov_base_remove_js:
+      type: boolean
+      label: 'Remove JS libraries from base theme.'
+    localgov_base_add_unpublished_background_colour:
+      type: boolean
+      label: 'Add background colour to unpublished content.'
+    localgov_base_add_draft_note_to_unpublished_content:
+      type: boolean
+      label: 'Add "[Draft]" to title of unpublished content.'


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)

it looks like child themes need their own config schema, even for settings defined in the base theme. This means that ECC Theme Gov and Intranet don’t know that the draft setting is supposed to be boolean.

Copied schema from localgov_base and change setting name in the first line.

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
