### PR TITLE
Only print the button for call out box link if there's a URL present.

### DIFF
--- a/ecc_theme/templates/paragraphs/paragraph--localgov-call-out-box.html.twig
+++ b/ecc_theme/templates/paragraphs/paragraph--localgov-call-out-box.html.twig
@@ -64,12 +64,14 @@
     {{ heading }}
   {% endif %}
     {{ content|without('localgov_button', 'localgov_background_image', 'localgov_colour_theme', 'localgov_header_text', 'localgov_heading_level', 'localgov_opens_in_a_new_window') }}
-    <a href="{{ button_url }}" class="call-out-box__link"
-      {% if open_in_new_window %} target="_blank" {% endif %}>
-      <span>{{ paragraph.localgov_button.getValue[0].title }}</span>
-      {% if open_in_new_window %}
-        <span class="visually-hidden"> {{ '(opens in a new window)'|t }}</span>
-      {% endif %}
-    </a>
+    {% if button_url %}
+      <a href="{{ button_url }}" class="call-out-box__link"
+        {% if open_in_new_window %} target="_blank" {% endif %}>
+        <span>{{ paragraph.localgov_button.getValue[0].title }}</span>
+        {% if open_in_new_window %}
+          <span class="visually-hidden"> {{ '(opens in a new window)'|t }}</span>
+        {% endif %}
+      </a>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Only print the callout link button if there is an actual link to print.

Resolves the problem of printing an empty button, meaning you always need to include a link.

part of https://eccservicetransformation.atlassian.net/browse/LP-175