### PR TITLE
Point gov theme libraries at the correct path for subsite css

### DIFF
--- a/ecc_theme_gov/ecc_theme_gov.libraries.yml
+++ b/ecc_theme_gov/ecc_theme_gov.libraries.yml
@@ -47,5 +47,5 @@ subsites:
   css:
     theme:
       css/subsites.css: { weight: 2 }
-      subsites/fostering/fostering.css: { weight: 2 }
-      subsites/digitalessex/digitalessex.css: { weight: 2 }
+      css/subsites/fostering/fostering.css: { weight: 2 }
+      css/subsites/digitalessex/digitalessex.css: { weight: 2 }


### PR DESCRIPTION
Fixes CSS paths in ecc_theme_gov libraries file for the new subsites folders.