### PR TITLE
Do not let blockquote icon repeat

### DIFF
--- a/ecc_theme/css/ecc-shared/blockquote.css
+++ b/ecc_theme/css/ecc-shared/blockquote.css
@@ -15,9 +15,10 @@ blockquote.pull-out-quote__content:before {
   content: '';
   display: inline-block;
   height: 22px;
-  width: 34px;
+  width: 30px;
   margin-right: 0.5em;
   mask-size: 30px;
+  mask-repeat: no-repeat;
 }
 
 .pull-out-quote {


### PR DESCRIPTION
block quote icon is made with a mask.
It was repeating.
This makes it stop.
https://eccservicetransformation.atlassian.net/browse/LP-282
