### PR TITLE
Prevent directory page h2s from getting the red underline style

### DIFF
--- a/ecc_theme/css/ecc-shared/headings.css
+++ b/ecc_theme/css/ecc-shared/headings.css
@@ -33,6 +33,12 @@ h1::after,
   background-color: var(--color-accent);
 }
 
+.page-node-type-localgov-directories-page .field--label-above h2 {
+  margin-bottom: var(--vertical-rhythm-spacing);
+  padding-bottom: 0;
+  margin-top: 0;
+}
+
 .page-node-type-localgov-directories-page h2::after,
 .service-landing-page__contact h2::after,
 .localgov-alert-banner h2::after,

--- a/ecc_theme/css/ecc-shared/headings.css
+++ b/ecc_theme/css/ecc-shared/headings.css
@@ -33,6 +33,7 @@ h1::after,
   background-color: var(--color-accent);
 }
 
+.page-node-type-localgov-directories-page h2::after,
 .service-landing-page__contact h2::after,
 .localgov-alert-banner h2::after,
 .call-out-box h2::after,


### PR DESCRIPTION
Prevents directory page h2s from getting a red underline style.
Extends the existing paradigm of exclusions.
https://eccservicetransformation.atlassian.net/browse/LP-308