### PR TITLE
Make links essex blue on pink tint sections.

### DIFF
--- a/ecc_theme/css/ecc-shared/page-sections.css
+++ b/ecc_theme/css/ecc-shared/page-sections.css
@@ -57,6 +57,10 @@
   .media-with-text--default .media-with-text__body {
     background-color: var(--color-page-section-background-color-4);
   }
+
+  a {
+    color: var(--color-link);
+  }
 }
 
 .lgd-page-section--bg-colour-5 {


### PR DESCRIPTION
we have a situation where a section can have a pink background, but links remain white.
This changes links to use Essex blue, using the existing defined link colour variable.