### PR TITLE
Ensure blue links on lilac and grey section backgrounds

### DIFF
--- a/ecc_theme/css/ecc-shared/page-sections.css
+++ b/ecc_theme/css/ecc-shared/page-sections.css
@@ -41,6 +41,9 @@
   .media-with-text--default .media-with-text__body {
     background-color: var(--color-page-section-background-color-3);
   }
+  a {
+    color: var(--color-link);
+  }
 }
 
 /*
@@ -70,6 +73,9 @@
   .media-with-text--default,
   .media-with-text--default .media-with-text__body {
     background-color: var(--color-page-section-background-color-3);
+  }
+  a {
+    color: var(--color-link);
   }
 }
 


### PR DESCRIPTION
in https://eccservicetransformation.atlassian.net/browse/LP-285
we made links blue on the pink tint background.
Now we're doing the same for lilac tint and light grey.
https://eccservicetransformation.atlassian.net/browse/LP-354