### PR TITLE
Do not hide CYPAF breadcrumb on its own page.

### DIFF
--- a/ecc_theme_gov/ecc_theme_gov.theme
+++ b/ecc_theme_gov/ecc_theme_gov.theme
@@ -36,7 +36,7 @@ function ecc_theme_gov_preprocess_breadcrumb(&$variables): void {
   if (str_starts_with($alias, '/children-young-people-and-families')) {
     // If the breadcrumb array has more than one item and the second item's text
     // is "Children, young people and families".
-    if (count($variables['breadcrumb']) > 1 && $variables['breadcrumb'][1]['text'] === 'Children, young people and families') {
+    if (count($variables['breadcrumb']) > 2 && $variables['breadcrumb'][1]['text'] === 'Children, young people and families') {
       // Unset the second breadcrumb item.
       unset($variables['breadcrumb'][1]);
     }


### PR DESCRIPTION
on this page https://www.essex.gov.uk/children-young-people-and-families 
the breadcrumb is shortened.
This is fine on all other relevant pages, e.g. https://www.essex.gov.uk/children-young-people-and-families/report-concern-about-child
but not here. We want the title of the page to be shown in the breadcrumb here.
https://eccservicetransformation.atlassian.net/browse/LP-341