### PR TITLE
Only hide children etc breadcrumb element on fostering pages

### DIFF
--- a/ecc_theme_gov/ecc_theme_gov.theme
+++ b/ecc_theme_gov/ecc_theme_gov.theme
@@ -33,7 +33,7 @@ function ecc_theme_gov_preprocess_breadcrumb(&$variables): void {
   $alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
 
   // Manipulate the breadcrumbs for fostering pages.
-  if (str_starts_with($alias, '/children-young-people-and-families')) {
+  if (str_starts_with($alias, '/children-young-people-and-families/fostering')) {
     // If the breadcrumb array has more than one item and the second item's text
     // is "Children, young people and families".
     if (count($variables['breadcrumb']) > 2 && $variables['breadcrumb'][1]['text'] === 'Children, young people and families') {


### PR DESCRIPTION
we want the whole breadcrumb on non fostering pages, so only apply the breadcrumb modification to fostering pages.
https://eccservicetransformation.atlassian.net/browse/LP-341