### PR TITLE
Add archived boolean definitions to theme schemas to match new lgd base theme

### DIFF
--- a/ecc_theme_gov/config/schema/ecc_theme_gov.schema.yml
+++ b/ecc_theme_gov/config/schema/ecc_theme_gov.schema.yml
@@ -14,3 +14,6 @@ ecc_theme_gov.settings:
     localgov_base_add_draft_note_to_unpublished_content:
       type: boolean
       label: 'Add "[Draft]" to title of unpublished content.'
+    localgov_base_add_archived_note_to_archived_content:
+      type: boolean
+      label: 'Add "[Archived]" to title of archived content.'

--- a/ecc_theme_intranet/config/schema/ecc_theme_intranet.schema.yml
+++ b/ecc_theme_intranet/config/schema/ecc_theme_intranet.schema.yml
@@ -14,3 +14,6 @@ ecc_theme_intranet.settings:
     localgov_base_add_draft_note_to_unpublished_content:
       type: boolean
       label: 'Add "[Draft]" to title of unpublished content.'
+    localgov_base_add_archived_note_to_archived_content:
+      type: boolean
+      label: 'Add "[Archived]" to title of archived content.'


### PR DESCRIPTION
v 1.8.11 of localgov_base introduces a theme setting for marking nodes as archived (like the existing draft setting)
this change adds that variable into our schemas, just like was done for the draft setting last year.
https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?selectedIssue=LP-278