### PR TITLE
Apply hover and focus states to link for digital essex logo

### DIFF
--- a/ecc_theme_gov/css/subsites/digitalessex/digitalessex.css
+++ b/ecc_theme_gov/css/subsites/digitalessex/digitalessex.css
@@ -48,17 +48,26 @@ body.subsite-extra--color-digitalessex {
       margin-top: 1em;
     }
 
-    .subsite-extra__title>a {
+    .subsite-extra__title > a {
       color: var(--color-white);
       text-indent: -9999px;
       overflow: hidden;
       display: block;
-      height: 4em;
+      height: 3em;
       width: 10em;
     }
 
-    .subsite-extra__title>a:focus {
+    .subsite-extra__title > a:hover {
+      background-color: transparent;
+      border: 1px dashed white;
+    }
+
+    .subsite-extra__title > a:focus {
+      outline: none;
+      box-shadow: none;
       color: var(--color-black);
+      background-color: transparent;
+      border: 1px dashed white;
     }
   }
 


### PR DESCRIPTION
for digital essex subsite theme the logo is a link, but it was inheriting inappropriate hover and focus states.
This makes them a nice dashed white border.
https://eccservicetransformation.atlassian.net/browse/LP-366